### PR TITLE
reference_to_pose function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,9 @@ find_package(ament_cmake REQUIRED)
 find_package(rclcpp)
 find_package(ament_cmake_python REQUIRED)
 find_package(Eigen3 REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(tf2 REQUIRED)
+find_package(tf2_geometry_msgs REQUIRED)
 
 include_directories(include)
 
@@ -18,7 +21,13 @@ target_include_directories(${PROJECT_NAME} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)
 
-ament_target_dependencies(${PROJECT_NAME} PUBLIC rclcpp Eigen3)
+ament_target_dependencies(${PROJECT_NAME} PUBLIC
+  rclcpp
+  Eigen3
+  geometry_msgs
+  tf2
+  tf2_geometry_msgs
+)
 
 ament_export_targets(${PROJECT_NAME} HAS_LIBRARY_TARGET)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,6 @@ find_package(rclcpp)
 find_package(ament_cmake_python REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(geometry_msgs REQUIRED)
-find_package(tf2 REQUIRED)
-find_package(tf2_geometry_msgs REQUIRED)
 
 include_directories(include)
 
@@ -25,8 +23,6 @@ ament_target_dependencies(${PROJECT_NAME} PUBLIC
   rclcpp
   Eigen3
   geometry_msgs
-  tf2
-  tf2_geometry_msgs
 )
 
 ament_export_targets(${PROJECT_NAME} HAS_LIBRARY_TARGET)

--- a/cpp_test/CMakeLists.txt
+++ b/cpp_test/CMakeLists.txt
@@ -8,6 +8,7 @@ add_executable(
     ${TEST_BINARY_NAME}
     test_math.cpp
     test_types.cpp
+    test_ros_conversions.cpp
 )
 
 target_link_libraries(

--- a/cpp_test/test_ros_conversions.cpp
+++ b/cpp_test/test_ros_conversions.cpp
@@ -1,0 +1,124 @@
+#include <gtest/gtest.h>
+#include <string>
+#include "vortex/utils/ros_conversions.hpp"
+#include "vortex/utils/types.hpp"
+
+// ---------- Compile-time concept tests ----------
+
+// Valid type for EulerPoseLike
+struct ValidEulerPose {
+    double x, y, z;
+    double roll, pitch, yaw;
+};
+
+// Valid type for EulerPoseLike with additional fields
+struct ValidEulerPoseExtra {
+    double x, y, z;
+    double roll, pitch, yaw;
+    double extra_field;  // additional field
+};
+
+// Invalid type for EulerPoseLike with quaternion fields
+struct QuatPose {
+    double x, y, z;
+    double qx, qy, qz, qw;
+};
+
+// Invalid: missing yaw
+struct MissingYaw {
+    double x, y, z;
+    double roll, pitch;
+};
+
+// Invalid: wrong type for roll
+struct WrongType {
+    double x, y, z;
+    std::string roll;  // not convertible to double
+    double pitch;
+    double yaw;
+};
+
+static_assert(vortex::utils::ros_conversions::EulerPoseLike<ValidEulerPose>,
+              "ValidEulerPose should satisfy EulerPoseLike");
+
+static_assert(
+    vortex::utils::ros_conversions::EulerPoseLike<ValidEulerPoseExtra>,
+    "ValidEulerPoseExtra should satisfy EulerPoseLike");
+
+static_assert(!vortex::utils::ros_conversions::EulerPoseLike<QuatPose>,
+              "QuatPose should NOT satisfy EulerPoseLike");
+
+static_assert(!vortex::utils::ros_conversions::EulerPoseLike<MissingYaw>,
+              "MissingYaw should NOT satisfy EulerPoseLike");
+
+static_assert(!vortex::utils::ros_conversions::EulerPoseLike<WrongType>,
+              "WrongType should NOT satisfy EulerPoseLike");
+
+// Ensure the function template accepts valid types
+static_assert(
+    std::is_same_v<
+        decltype(vortex::utils::ros_conversions::euler_pose_to_pose_msg(
+            std::declval<ValidEulerPose>())),
+        geometry_msgs::msg::Pose>,
+    "euler_pose_to_pose_msg should accept ValidEulerPose");
+
+// Ensure the function template rejects invalid types
+template <typename T>
+concept FunctionAccepts = requires(T t) {
+    vortex::utils::ros_conversions::euler_pose_to_pose_msg(t);
+};
+
+static_assert(FunctionAccepts<ValidEulerPose>,
+              "Function should accept ValidEulerPose");
+
+static_assert(FunctionAccepts<ValidEulerPoseExtra>,
+              "Function should accept ValidEulerPoseExtra");
+
+static_assert(!FunctionAccepts<QuatPose>,
+              "Function should NOT accept QuatPose");
+
+static_assert(!FunctionAccepts<MissingYaw>,
+              "Function should NOT accept MissingYaw");
+
+static_assert(!FunctionAccepts<WrongType>,
+              "Function should NOT accept WrongType");
+
+// ---------- Runtime tests ----------
+
+TEST(euler_pose_to_pose_msg, test_default_eta_conversion) {
+    vortex::utils::types::Eta eta;
+
+    auto pose = vortex::utils::ros_conversions::euler_pose_to_pose_msg(eta);
+
+    EXPECT_NEAR(pose.position.x, eta.x, 1e-3);
+    EXPECT_NEAR(pose.position.y, eta.y, 1e-3);
+    EXPECT_NEAR(pose.position.z, eta.z, 1e-3);
+
+    // Expect identity quaternion for zero roll, pitch, yaw
+    EXPECT_NEAR(pose.orientation.x, 0.0, 1e-3);
+    EXPECT_NEAR(pose.orientation.y, 0.0, 1e-3);
+    EXPECT_NEAR(pose.orientation.z, 0.0, 1e-3);
+    EXPECT_NEAR(pose.orientation.w, 1.0, 1e-3);
+}
+
+TEST(euler_pose_to_pose_msg, test_nonzero_rotation) {
+    struct Pose {
+        double x = 1.0, y = 2.0, z = 3.0;
+        double roll = 1.0;
+        double pitch = 1.0;
+        double yaw = 1.0;
+    };
+
+    Pose p;
+
+    auto pose = vortex::utils::ros_conversions::euler_pose_to_pose_msg(p);
+
+    EXPECT_NEAR(pose.position.x, 1.0, 1e-3);
+    EXPECT_NEAR(pose.position.y, 2.0, 1e-3);
+    EXPECT_NEAR(pose.position.z, 3.0, 1e-3);
+
+    EXPECT_NEAR(pose.orientation.x, 0.1675, 1e-3);
+    EXPECT_NEAR(pose.orientation.y, 0.5463, 1e-3);
+    EXPECT_NEAR(pose.orientation.z, 0.1675, 1e-3);
+    EXPECT_NEAR(pose.orientation.w, 0.786, 1e-3);
+}

--- a/include/vortex/utils/ros_conversions.hpp
+++ b/include/vortex/utils/ros_conversions.hpp
@@ -1,20 +1,20 @@
 #ifndef VORTEX_UTILS__ROS_CONVERSIONS_HPP_
 #define VORTEX_UTILS__ROS_CONVERSIONS_HPP_
 
-#include "math.hpp"
 #include <geometry_msgs/msg/pose.hpp>
+#include "math.hpp"
 
 namespace vortex::utils::ros_conversions {
 
-template <typename T>  
-concept PoseLike = requires(const T& t) {  
-    { t.x }     -> std::convertible_to<double>;  
-    { t.y }     -> std::convertible_to<double>;  
-    { t.z }     -> std::convertible_to<double>;  
-    { t.roll }  -> std::convertible_to<double>;  
-    { t.pitch } -> std::convertible_to<double>;  
-    { t.yaw }   -> std::convertible_to<double>;  
-};  
+template <typename T>
+concept PoseLike = requires(const T& t) {
+    { t.x } -> std::convertible_to<double>;
+    { t.y } -> std::convertible_to<double>;
+    { t.z } -> std::convertible_to<double>;
+    { t.roll } -> std::convertible_to<double>;
+    { t.pitch } -> std::convertible_to<double>;
+    { t.yaw } -> std::convertible_to<double>;
+};
 
 template <PoseLike T>
 geometry_msgs::msg::Pose reference_to_pose(const T& ref) {

--- a/include/vortex/utils/ros_conversions.hpp
+++ b/include/vortex/utils/ros_conversions.hpp
@@ -6,6 +6,17 @@
 
 namespace vortex::utils::ros_conversions {
 
+/**
+ * @brief Concept describing a generic pose-like type.
+ *
+ * A type satisfies this concept if it exposes the following fields,
+ * all convertible to double:
+ * - x, y, z  (position components)
+ * - roll, pitch, yaw  (orientation expressed as Euler angles)
+ *
+ *
+ * @tparam T The candidate type to check.
+ */
 template <typename T>
 concept PoseLike = requires(const T& t) {
     { t.x } -> std::convertible_to<double>;
@@ -16,6 +27,20 @@ concept PoseLike = requires(const T& t) {
     { t.yaw } -> std::convertible_to<double>;
 };
 
+/**
+ * @brief Convert a pose-like reference structure into a ROS Pose message.
+ *
+ * The function reads position (x, y, z) and orientation (roll, pitch, yaw)
+ * from the input object and constructs a corresponding
+ * `geometry_msgs::msg::Pose`.
+ *
+ * Orientation is internally converted from Euler angles (roll, pitch, yaw)
+ * into a quaternion via `vortex::utils::math::euler_to_quat()`.
+ *
+ * @tparam T A type satisfying the PoseLike concept.
+ * @param ref The input pose-like object.
+ * @return A `geometry_msgs::msg::Pose` containing the converted pose.
+ */
 template <PoseLike T>
 geometry_msgs::msg::Pose reference_to_pose(const T& ref) {
     geometry_msgs::msg::Pose pose;

--- a/include/vortex/utils/ros_conversions.hpp
+++ b/include/vortex/utils/ros_conversions.hpp
@@ -7,7 +7,7 @@
 namespace vortex::utils::ros_conversions {
 
 /**
- * @brief Concept describing a generic pose-like type.
+ * @brief Concept describing an Euler pose type expressed in XYZ + RPY form.
  *
  * A type satisfies this concept if it exposes the following fields,
  * all convertible to double:
@@ -18,7 +18,7 @@ namespace vortex::utils::ros_conversions {
  * @tparam T The candidate type to check.
  */
 template <typename T>
-concept PoseLike = requires(const T& t) {
+concept EulerPoseLike = requires(const T& t) {
     { t.x } -> std::convertible_to<double>;
     { t.y } -> std::convertible_to<double>;
     { t.z } -> std::convertible_to<double>;
@@ -28,7 +28,7 @@ concept PoseLike = requires(const T& t) {
 };
 
 /**
- * @brief Convert a pose-like reference structure into a ROS Pose message.
+ * @brief Convert a Euler pose-like structure into a ROS Pose message.
  *
  * The function reads position (x, y, z) and orientation (roll, pitch, yaw)
  * from the input object and constructs a corresponding
@@ -37,12 +37,12 @@ concept PoseLike = requires(const T& t) {
  * Orientation is internally converted from Euler angles (roll, pitch, yaw)
  * into a quaternion via `vortex::utils::math::euler_to_quat()`.
  *
- * @tparam T A type satisfying the PoseLike concept.
+ * @tparam T A type satisfying the EulerPoseLike concept.
  * @param ref The input pose-like object.
  * @return A `geometry_msgs::msg::Pose` containing the converted pose.
  */
-template <PoseLike T>
-geometry_msgs::msg::Pose reference_to_pose(const T& ref) {
+template <EulerPoseLike T>
+geometry_msgs::msg::Pose euler_to_pose_msg(const T& ref) {
     geometry_msgs::msg::Pose pose;
     pose.position.x = ref.x;
     pose.position.y = ref.y;

--- a/include/vortex/utils/ros_conversions.hpp
+++ b/include/vortex/utils/ros_conversions.hpp
@@ -42,7 +42,7 @@ concept EulerPoseLike = requires(const T& t) {
  * @return A `geometry_msgs::msg::Pose` containing the converted pose.
  */
 template <EulerPoseLike T>
-geometry_msgs::msg::Pose euler_to_pose_msg(const T& ref) {
+geometry_msgs::msg::Pose euler_pose_to_pose_msg(const T& ref) {
     geometry_msgs::msg::Pose pose;
     pose.position.x = ref.x;
     pose.position.y = ref.y;

--- a/include/vortex/utils/ros_conversions.hpp
+++ b/include/vortex/utils/ros_conversions.hpp
@@ -1,7 +1,10 @@
 #ifndef VORTEX_UTILS__ROS_CONVERSIONS_HPP_
 #define VORTEX_UTILS__ROS_CONVERSIONS_HPP_
 
+#include <concepts>
+#include <eigen3/Eigen/Dense>
 #include <geometry_msgs/msg/pose.hpp>
+
 #include "math.hpp"
 
 namespace vortex::utils::ros_conversions {
@@ -12,7 +15,7 @@ namespace vortex::utils::ros_conversions {
  * A type satisfies this concept if it exposes the following fields,
  * all convertible to double:
  * - x, y, z  (position components)
- * - roll, pitch, yaw  (orientation expressed as Euler angles)
+ * - roll, pitch, yaw  (orientation expressed as Euler/RPY angles)
  *
  *
  * @tparam T The candidate type to check.
@@ -22,10 +25,60 @@ concept EulerPoseLike = requires(const T& t) {
     { t.x } -> std::convertible_to<double>;
     { t.y } -> std::convertible_to<double>;
     { t.z } -> std::convertible_to<double>;
+
     { t.roll } -> std::convertible_to<double>;
     { t.pitch } -> std::convertible_to<double>;
     { t.yaw } -> std::convertible_to<double>;
 };
+
+/**
+ * @brief Concept describing a pose type expressed in XYZ + quaternion form.
+ *
+ * A type satisfies this concept if it exposes the following fields:
+ *  - x, y, z              (position components)
+ *  - qw, qx, qy, qz       (quaternion orientation)
+ *
+ *
+ * @tparam T The candidate type to check.
+ */
+template <typename T>
+concept QuatPoseLike = requires(const T& t) {
+    { t.x } -> std::convertible_to<double>;
+    { t.y } -> std::convertible_to<double>;
+    { t.z } -> std::convertible_to<double>;
+
+    { t.qw } -> std::convertible_to<double>;
+    { t.qx } -> std::convertible_to<double>;
+    { t.qy } -> std::convertible_to<double>;
+    { t.qz } -> std::convertible_to<double>;
+};
+
+/**
+ * @brief Concept for Eigen-based 6-vector Euler poses:
+ *        [x, y, z, roll, pitch, yaw].
+ *
+ * Accepts:
+ *   - Eigen::Matrix<double, 6, 1>
+ *
+ *
+ * @tparam T The candidate type.
+ */
+template <typename T>
+concept Eigen6dEuler = std::same_as<T, Eigen::Matrix<double, 6, 1>>;
+
+/**
+ * @brief Master concept representing any supported pose-like structure.
+ *
+ * A type satisfies PoseLike if it matches *any* of the following:
+ *   - EulerPoseLike  (XYZ + RPY)
+ *   - QuatPoseLike   (XYZ + quaternion)
+ *   - Eigen6dEuler   (Matrix<6,1>)
+ *
+ *
+ * @tparam T The candidate pose type.
+ */
+template <typename T>
+concept PoseLike = EulerPoseLike<T> || QuatPoseLike<T> || Eigen6dEuler<T>;
 
 /**
  * @brief Convert a Euler pose-like structure into a ROS Pose message.
@@ -37,13 +90,14 @@ concept EulerPoseLike = requires(const T& t) {
  * Orientation is internally converted from Euler angles (roll, pitch, yaw)
  * into a quaternion via `vortex::utils::math::euler_to_quat()`.
  *
- * @tparam T A type satisfying the EulerPoseLike concept.
- * @param ref The input pose-like object.
+ * @tparam T A type satisfying the `EulerPoseLike` concept.
+ * @param ref The input `EulerPoseLike` object.
  * @return A `geometry_msgs::msg::Pose` containing the converted pose.
  */
 template <EulerPoseLike T>
-geometry_msgs::msg::Pose euler_pose_to_pose_msg(const T& ref) {
+geometry_msgs::msg::Pose pose_like_to_pose_msg(const T& ref) {
     geometry_msgs::msg::Pose pose;
+
     pose.position.x = ref.x;
     pose.position.y = ref.y;
     pose.position.z = ref.z;
@@ -55,6 +109,62 @@ geometry_msgs::msg::Pose euler_pose_to_pose_msg(const T& ref) {
     pose.orientation.y = quat.y();
     pose.orientation.z = quat.z();
     pose.orientation.w = quat.w();
+
+    return pose;
+}
+
+/**
+ * @brief Convert a quaternion pose-like structure into a ROS Pose message.
+ *
+ * The function reads position (x, y, z) and orientation (qw, qx, qy, qz)
+ * from the input object and constructs a corresponding
+ * `geometry_msgs::msg::Pose`.
+ *
+ * @tparam T A type satisfying the `QuatPoseLike` concept.
+ * @param ref The input `QuatPoseLike` object.
+ * @return A `geometry_msgs::msg::Pose` containing the converted pose.
+ */
+template <QuatPoseLike T>
+geometry_msgs::msg::Pose pose_like_to_pose_msg(const T& ref) {
+    geometry_msgs::msg::Pose pose;
+
+    pose.position.x = ref.x;
+    pose.position.y = ref.y;
+    pose.position.z = ref.z;
+
+    pose.orientation.x = ref.qx;
+    pose.orientation.y = ref.qy;
+    pose.orientation.z = ref.qz;
+    pose.orientation.w = ref.qw;
+
+    return pose;
+}
+
+/**
+ * @brief Convert an Eigen 6d-vector [x, y, z, roll, pitch, yaw]
+ *        into a ROS Pose message.
+ *
+ * Orientation is internally converted from v(3), v(4), v(5)
+ * into a quaternion via `vortex::utils::math::euler_to_quat()`.
+ *
+ * @tparam T A type satisfying the `Eigen6dEuler` concept.
+ * @param v The 6d-vector containing position and Euler angles.
+ * @return A `geometry_msgs::msg::Pose` containing the converted pose.
+ */
+template <Eigen6dEuler T>
+geometry_msgs::msg::Pose pose_like_to_pose_msg(const T& v) {
+    geometry_msgs::msg::Pose pose;
+
+    pose.position.x = v(0);
+    pose.position.y = v(1);
+    pose.position.z = v(2);
+
+    Eigen::Quaterniond q = vortex::utils::math::euler_to_quat(v(3), v(4), v(5));
+
+    pose.orientation.x = q.x();
+    pose.orientation.y = q.y();
+    pose.orientation.z = q.z();
+    pose.orientation.w = q.w();
 
     return pose;
 }

--- a/include/vortex/utils/ros_conversions.hpp
+++ b/include/vortex/utils/ros_conversions.hpp
@@ -1,26 +1,39 @@
-#ifndef ROS_CONVERSIONS_HPP
-#define ROS_CONVERSIONS_HPP
+#ifndef VORTEX_UTILS__ROS_CONVERSIONS_HPP_
+#define VORTEX_UTILS__ROS_CONVERSIONS_HPP_
 
-#include <tf2/LinearMath/Quaternion.h>
+#include "math.hpp"
 #include <geometry_msgs/msg/pose.hpp>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 namespace vortex::utils::ros_conversions {
 
-template <typename T>
+template <typename T>  
+concept PoseLike = requires(const T& t) {  
+    { t.x }     -> std::convertible_to<double>;  
+    { t.y }     -> std::convertible_to<double>;  
+    { t.z }     -> std::convertible_to<double>;  
+    { t.roll }  -> std::convertible_to<double>;  
+    { t.pitch } -> std::convertible_to<double>;  
+    { t.yaw }   -> std::convertible_to<double>;  
+};  
+
+template <PoseLike T>
 geometry_msgs::msg::Pose reference_to_pose(const T& ref) {
     geometry_msgs::msg::Pose pose;
     pose.position.x = ref.x;
     pose.position.y = ref.y;
     pose.position.z = ref.z;
 
-    tf2::Quaternion q;
-    q.setRPY(ref.roll, ref.pitch, ref.yaw);
-    pose.orientation = tf2::toMsg(q);
+    Eigen::Quaterniond quat =
+        vortex::utils::math::euler_to_quat(ref.roll, ref.pitch, ref.yaw);
+
+    pose.orientation.x = quat.x();
+    pose.orientation.y = quat.y();
+    pose.orientation.z = quat.z();
+    pose.orientation.w = quat.w();
 
     return pose;
 }
 
 }  // namespace vortex::utils::ros_conversions
 
-#endif  // ROS_CONVERSIONS_HPP
+#endif  // VORTEX_UTILS__ROS_CONVERSIONS_HPP_

--- a/include/vortex/utils/ros_conversions.hpp
+++ b/include/vortex/utils/ros_conversions.hpp
@@ -1,0 +1,26 @@
+#ifndef ROS_CONVERSIONS_HPP
+#define ROS_CONVERSIONS_HPP
+
+#include <tf2/LinearMath/Quaternion.h>
+#include <geometry_msgs/msg/pose.hpp>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+
+namespace vortex::utils::ros_conversions {
+
+template <typename T>
+geometry_msgs::msg::Pose reference_to_pose(const T& ref) {
+    geometry_msgs::msg::Pose pose;
+    pose.position.x = ref.x;
+    pose.position.y = ref.y;
+    pose.position.z = ref.z;
+
+    tf2::Quaternion q;
+    q.setRPY(ref.roll, ref.pitch, ref.yaw);
+    pose.orientation = tf2::toMsg(q);
+
+    return pose;
+}
+
+}  // namespace vortex::utils::ros_conversions
+
+#endif  // ROS_CONVERSIONS_HPP

--- a/package.xml
+++ b/package.xml
@@ -15,8 +15,6 @@
   <depend>python3-numpy</depend>
   <depend>python3-scipy</depend>
   <depend>geometry_msgs</depend>
-  <depend>tf2</depend>
-  <depend>tf2_geometry_msgs</depend>
 
 
   <test_depend>ament_cmake_pytest</test_depend>

--- a/package.xml
+++ b/package.xml
@@ -15,6 +15,9 @@
   <depend>python3-numpy</depend>
   <depend>python3-scipy</depend>
   <depend>geometry_msgs</depend>
+  <depend>tf2</depend>
+  <depend>tf2_geometry_msgs</depend>
+
 
   <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>


### PR DESCRIPTION
reference_to_pose is templated for now, to avoid a dependency on vortex_msgs. 
Can therefore be called like this:
```cpp
pose = vortex::utils::ros_conversions::reference_to_pose(reference);
```
