### PR TITLE
exported utils, removed unnecessary dependency

### DIFF
--- a/vortex_utils_ros/CMakeLists.txt
+++ b/vortex_utils_ros/CMakeLists.txt
@@ -37,7 +37,7 @@ install(
 
 ament_export_targets(vortex_utils_ros_targets)
 
-ament_export_dependencies()
+ament_export_dependencies(vortex_utils)
 ament_export_include_directories(include)
 ament_python_install_package(${PROJECT_NAME})
 

--- a/vortex_utils_ros_tf/CMakeLists.txt
+++ b/vortex_utils_ros_tf/CMakeLists.txt
@@ -5,7 +5,6 @@ set(CMAKE_CXX_STANDARD 20)
 add_compile_options(-Wall -Wextra -Wpedantic)
 
 find_package(ament_cmake REQUIRED)
-find_package(vortex_utils REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(ament_cmake_python REQUIRED)
 find_package(geometry_msgs REQUIRED)
@@ -21,7 +20,6 @@ target_include_directories(vortex_utils_ros_tf INTERFACE
 )
 
 ament_target_dependencies(vortex_utils_ros_tf INTERFACE
-  vortex_utils
   rclcpp
   tf2
   tf2_ros

--- a/vortex_utils_ros_tf/package.xml
+++ b/vortex_utils_ros_tf/package.xml
@@ -10,7 +10,6 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>rclcpp</depend>
-  <depend>vortex_utils</depend>
   <depend>eigen</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>


### PR DESCRIPTION
Correctly export vortex_utils from vortex_utils_ros so user don't need to call find_package on both.
Also removed currently unused vortex_utils dep in vortex_utils_ros_tf